### PR TITLE
chore: remove unimplemented next_planned_action translation entries

### DIFF
--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -316,16 +316,6 @@
           "additional_battery_charging_block": "Zusatzakku lädt: Entladung blockiert"
         }
       },
-      "next_planned_action": {
-        "name": "Geplante nächste Aktion",
-        "state": {
-          "none": "Keine Aktion geplant",
-          "charge": "Geplantes Laden",
-          "discharge": "Geplante Entladung",
-          "wait": "Warten",
-          "emergency": "Notladung"
-        }
-      },
       "next_action_state": {
         "name": "Nächste Aktion",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -316,16 +316,6 @@
           "additional_battery_charging_block": "Additional battery charging: discharge blocked"
         }
       },
-      "next_planned_action": {
-        "name": "Next planned action",
-        "state": {
-          "none": "No action planned",
-          "charge": "Planned charging",
-          "discharge": "Planned discharge",
-          "wait": "Wait",
-          "emergency": "Emergency charge"
-        }
-      },
       "next_action_state": {
         "name": "Next action",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -316,16 +316,6 @@
           "additional_battery_charging_block": "Batterie supplémentaire en charge : décharge bloquée"
         }
       },
-      "next_planned_action": {
-        "name": "Prochaine action planifiée",
-        "state": {
-          "none": "Aucune action planifiée",
-          "charge": "Charge planifiée",
-          "discharge": "Décharge planifiée",
-          "wait": "Attendre",
-          "emergency": "Charge d’urgence"
-        }
-      },
       "next_action_state": {
         "name": "Prochaine action",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -316,16 +316,6 @@
           "additional_battery_charging_block": "Extra batterij laadt: ontladen geblokkeerd"
         }
       },
-      "next_planned_action": {
-        "name": "Volgende geplande actie",
-        "state": {
-          "none": "Geen actie gepland",
-          "charge": "Gepland laden",
-          "discharge": "Gepland ontladen",
-          "wait": "Wachten",
-          "emergency": "Noodladen"
-        }
-      },
       "next_action_state": {
         "name": "Volgende actie",
         "state": {


### PR DESCRIPTION
## Summary

The sensor key `next_planned_action` was never implemented — it has no entry in `sensor.py` and the coordinator never sets it. The translation blocks were present in all four language files (de, en, fr, nl), causing the entity `battery_smartflow_ai_geplante_nachste_aktion` (and its equivalents) to appear as permanently **unavailable** in Home Assistant.

This PR removes the orphaned translation entries from all four files.

## Changes

- `translations/de.json` — removed `next_planned_action` block
- `translations/en.json` — removed `next_planned_action` block  
- `translations/fr.json` — removed `next_planned_action` block
- `translations/nl.json` — removed `next_planned_action` block

## Notes

If `next_planned_action` is planned for future implementation, the translation entries can be re-added together with the sensor and coordinator changes in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)